### PR TITLE
fix(dependabot): Delete bad package-ecosystems in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -181,38 +181,3 @@ updates:
     commit-message:
       prefix: "chore(deps):"
       include: "scope"
-
-  # Gomod dependencies for Go
-  - package-ecosystem: "gomod"
-    directory: "/images/go"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:15"
-    open-pull-requests-limit: 3
-    reviewers:
-      - "ironwolphern"
-    labels:
-      - "dependencies"
-      - "go"
-      - "gomod"
-    commit-message:
-      prefix: "chore(deps):"
-      include: "scope"
-
-  # Terraform dependencies for Terraform
-  - package-ecosystem: "terraform"
-    directory: "/images/terraform"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
-    open-pull-requests-limit: 3
-    reviewers:
-      - "ironwolphern"
-    labels:
-      - "dependencies"
-      - "terraform"
-    commit-message:
-      prefix: "chore(deps):"
-      include: "scope"


### PR DESCRIPTION
This pull request simplifies the `.github/dependabot.yml` configuration by removing unused dependency update configurations for specific ecosystems. 

Configuration cleanup:

* Removed the update configuration for `gomod` dependencies in the `/images/go` directory, including its schedule, reviewers, and labels.
* Removed the update configuration for `terraform` dependencies in the `/images/terraform` directory, including its schedule, reviewers, and labels.