### PR TITLE
fix(bugs): Fix bugs in images go and ansible when push images

### DIFF
--- a/images/ansible/Dockerfile
+++ b/images/ansible/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc=4:12.* \
     libffi-dev=3.* \
     libssl-dev=3.* \
+    libonig-dev=6.* \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp

--- a/images/go/Dockerfile
+++ b/images/go/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache \
     git=2.49.1-r0 \
     ca-certificates=20250619-r0 \
     gcc=14.2.0-r6 \
-    musl-dev=1.2.5-r10
+    musl-dev=1.2.5-r10 \
+    binutils=2.44-r2
 
 WORKDIR /tmp
 


### PR DESCRIPTION
This pull request updates dependencies in Dockerfiles for the `ansible` and `go` images. The changes ensure the inclusion of additional libraries required for builds and runtime compatibility.

### Dependency updates:

* [`images/ansible/Dockerfile`](diffhunk://#diff-33b17c2b8953e53491d05afcb0bf7ed7b09fd2d9edc80c93533b833d400402f1R13): Added `libonig-dev=6.*` to the list of packages installed via `apt-get`. This library is likely required for enabling Oniguruma regular expression support.
* [`images/go/Dockerfile`](diffhunk://#diff-4e1277b03db3f3274a380ca0018f7aaa0e8cfd110cc6bf4f75e72b571afe5785L13-R14): Added `binutils=2.44-r2` to the list of packages installed via `apk add`. This update includes essential binary utilities for development.