### PR TITLE
fix(ci-cd): Fix bugs in push images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -199,7 +199,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./images/${{ matrix.image }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: ${{ matrix.build_args }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -199,7 +199,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./images/${{ matrix.image }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: ${{ matrix.build_args }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/images/ansible/Dockerfile
+++ b/images/ansible/Dockerfile
@@ -4,7 +4,7 @@
 ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-slim AS builder
 
-# Install build dependencies
+# Install build dependencies and tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential=12.* \
     gcc=4:12.* \

--- a/images/go/Dockerfile
+++ b/images/go/Dockerfile
@@ -30,7 +30,7 @@ ARG GO_VERSION=1.24
 ARG ALPINE_VERSION=3.22
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS production
 
-# Install runtime dependencies
+# Install runtime dependencies and tools
 RUN apk add --no-cache \
     git=2.49.1-r0 \
     curl=8.14.1-r1 \

--- a/images/go/Dockerfile
+++ b/images/go/Dockerfile
@@ -11,7 +11,8 @@ RUN apk add --no-cache \
     ca-certificates=20250619-r0 \
     gcc=14.2.0-r6 \
     musl-dev=1.2.5-r10 \
-    binutils=2.44-r2
+    binutils=2.44-r2 \
+    build-base=0.5-r3
 
 WORKDIR /tmp
 

--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --user --no-cache-dir -r requirements.txt
 ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-slim AS production
 
-# Install runtime dependencies
+# Install runtime dependencies and tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=1:2.* \
     curl=7.* \

--- a/images/terraform/Dockerfile
+++ b/images/terraform/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSL https://github.com/terraform-linters/tflint/releases/download/v${
 ARG ALPINE_VERSION=3.22
 FROM alpine:${ALPINE_VERSION} AS production
 
-# Install runtime dependencies
+# Install runtime dependencies and tools
 RUN apk add --no-cache \
     bash=5.2.37-r0 \
     git=2.49.1-r0 \


### PR DESCRIPTION
This pull request updates several Dockerfiles to include additional tools in the build and runtime environments. The main changes involve updating package installation commands to include new dependencies and improving the development and runtime toolsets.

### Build Environment Updates:
* [`images/ansible/Dockerfile`](diffhunk://#diff-33b17c2b8953e53491d05afcb0bf7ed7b09fd2d9edc80c93533b833d400402f1L7-R7): Enhanced the build environment by updating the comment to reflect the installation of both build dependencies and tools.
* [`images/go/Dockerfile`](diffhunk://#diff-4e1277b03db3f3274a380ca0018f7aaa0e8cfd110cc6bf4f75e72b571afe5785L14-R15): Added `build-base=0.5-r3` to the build dependencies for a more comprehensive toolchain.

### Runtime Environment Updates:
* [`images/go/Dockerfile`](diffhunk://#diff-4e1277b03db3f3274a380ca0018f7aaa0e8cfd110cc6bf4f75e72b571afe5785L32-R33): Updated the comment to indicate the installation of both runtime dependencies and tools.
* [`images/python/Dockerfile`](diffhunk://#diff-d34d84ab5c1cb78f60c0f5cdc93b33287b39802a4a1bc7ca904cbd7f80a90c8dL27-R27): Updated the runtime environment to include tools alongside runtime dependencies.
* [`images/terraform/Dockerfile`](diffhunk://#diff-2dba6debbccdbfdfb4b096ea493aea4498ae118e5e50543aefbbf42ce323409dL38-R38): Improved runtime environment by specifying the inclusion of tools in addition to runtime dependencies.