### PR TITLE
fix(go): fix push image in go

### DIFF
--- a/images/go/Dockerfile
+++ b/images/go/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
     gcc=14.2.0-r6 \
     musl-dev=1.2.5-r10 \
     binutils=2.44-r2 \
-    build-base=0.5-r3
+    binutils-gold=2.44-r2
 
 WORKDIR /tmp
 


### PR DESCRIPTION
This pull request updates the dependencies in the `images/go/Dockerfile` to replace `build-base` with `binutils-gold`.

Dependency update:

* [`images/go/Dockerfile`](diffhunk://#diff-4e1277b03db3f3274a380ca0018f7aaa0e8cfd110cc6bf4f75e72b571afe5785L15-R15): Replaced the `build-base` package (version `0.5-r3`) with `binutils-gold` (version `2.44-r2`) to adjust the toolchain dependencies.