### PR TITLE
fix(workflows): fix some bugs in workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: 'Build and test image'
         if: steps.should_build.outputs.build == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./images/${{ matrix.image }}
           platforms: linux/amd64
@@ -258,7 +258,7 @@ jobs:
         if: |
           steps.should_build.outputs.build == 'true' &&
           (github.ref == 'refs/heads/main' || github.event.inputs.push_images == 'true')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./images/${{ matrix.image }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -257,28 +257,23 @@ jobs:
 
             try {
               execSync('git add .');
-              // Check if there are staged changes
               try {
                 execSync('git diff --staged --quiet');
                 console.log('No changes to commit');
                 process.exit(0);
               } catch {
-                // There are changes to commit; proceed with commit and PR creation
+                // There are changes to commit; proceed with commit and push
+                try {
+                  execSync('git commit -m "Update dependencies"', { stdio: 'inherit' });
+                  execSync('git push origin HEAD', { stdio: 'inherit' });
+                  console.log('Successfully committed and pushed changes');
+                } catch (error) {
+                  console.error('Error committing or pushing changes:', error);
+                  process.exit(1);
+                }
               }
             } catch (err) {
               console.error('Error running git commands:', err);
-              process.exit(1);
-            }
-
-            # Proceed with commit and PR creation only if there are changes
-            const { execSync } = require('child_process');
-
-            try {
-              execSync('git commit -m "Update dependencies"', { stdio: 'inherit' });
-              execSync('git push origin HEAD', { stdio: 'inherit' });
-              console.log('Successfully committed and pushed changes');
-            } catch (error) {
-              console.error('Error committing or pushing changes:', error);
               process.exit(1);
             }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,6 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value={{major}}.{{minor}}
-            type=raw,value={{major}}
 
       - name: 'Build and push release image'
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             type=raw,value={{major}}
 
       - name: 'Build and push release image'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./images/${{ matrix.image }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -102,7 +102,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 'Build image for scanning'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./images/${{ matrix.image }}
           build-args: ${{ matrix.build_args }}


### PR DESCRIPTION
This pull request includes updates to multiple GitHub Actions workflows to improve functionality and maintain compatibility with the latest tools. The most notable changes involve upgrading the `docker/build-push-action` to version 6 and simplifying the dependency update process.

### Workflow Updates:

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L199-R199): Upgraded `docker/build-push-action` from version 5 to version 6 in both the build and push steps for improved functionality and support for multiple platforms. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L199-R199) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L261-R261)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L84-R86): Upgraded `docker/build-push-action` to version 6 and removed redundant tag definitions for streamlined release image builds.
* [`.github/workflows/security-scan.yml`](diffhunk://#diff-1adb34cd46df4e96bfa50d4b5ebf5c4f1bfcbaa514a44e9151f75efb6033d937L105-R105): Upgraded `docker/build-push-action` to version 6 for building images used in security scans.

### Dependency Update Workflow Simplification:

* [`.github/workflows/dependency-update.yml`](diffhunk://#diff-6e666a5e073d557b95cc901156d2b8d30c4d13d7c90be1d67549d7e1c884bae7L260-R265): Simplified the script by removing unnecessary error handling and redundant comments, and ensured that changes are committed and pushed if updates are detected. [[1]](diffhunk://#diff-6e666a5e073d557b95cc901156d2b8d30c4d13d7c90be1d67549d7e1c884bae7L260-R265) [[2]](diffhunk://#diff-6e666a5e073d557b95cc901156d2b8d30c4d13d7c90be1d67549d7e1c884bae7R274-R278)