### PR TITLE
fix(workflow): Fix timeout release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     name: 'Release Images'
     runs-on: ubuntu-latest
-    timeout-minutes: 40  # Timeout de 40 minutos para el job de release
+    timeout-minutes: 60  # Timeout de 60 minutos para el job de release
     strategy:
       max-parallel: 2  # Execute images in parallel (max 2 concurrent)
       matrix:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change increases the timeout for the "Release Images" job from 40 minutes to 60 minutes to allow for longer execution times.